### PR TITLE
refactor: use db-generated work session ids

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,3 +12,6 @@
 ## Documentation
 - When editing files in `ProjectDoc/`, keep `Eng.md` and `Heb.md` in sync and update their version and last-updated fields.
 
+## Notes
+- WorkSessions inserts should omit `id` so the database can generate it; include `id` only when updating existing records.
+

--- a/src/components/time-entry/TimeEntryForm.jsx
+++ b/src/components/time-entry/TimeEntryForm.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useMemo } from 'react';
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -34,7 +34,7 @@ const calculateRowPayment = (row, employee, services, getRateForDate) => {
   return 0;
 };
 
-export default function TimeEntryForm({ employee, services, onSubmit, getRateForDate, initialRows = null, selectedDate }) {
+export default function TimeEntryForm({ employee, services, onSubmit, getRateForDate, initialRows = null, selectedDate, allowAddRow = true }) {
   
   const createNewRow = (dateToUse) => ({
     id: crypto.randomUUID(),
@@ -129,10 +129,12 @@ export default function TimeEntryForm({ employee, services, onSubmit, getRateFor
         </AlertDescription>
       </Alert>
       
-      <div className="flex justify-between items-center pt-4">
-        <Button type="button" variant="outline" onClick={addRow}><Plus className="w-4 h-4 ml-2" />הוסף רישום</Button>
-        <Button type="submit" className="bg-gradient-to-r from-green-500 to-blue-500 text-white"><Save className="w-4 h-4 ml-2" />שמור רישומים</Button>
-      </div>
+        <div className={`flex ${allowAddRow ? 'justify-between' : 'justify-end'} items-center pt-4`}>
+          {allowAddRow && (
+            <Button type="button" variant="outline" onClick={addRow}><Plus className="w-4 h-4 ml-2" />הוסף רישום</Button>
+          )}
+          <Button type="submit" className="bg-gradient-to-r from-green-500 to-blue-500 text-white"><Save className="w-4 h-4 ml-2" />שמור רישומים</Button>
+        </div>
     </form>
   );
 }

--- a/src/components/time-entry/TimeEntryTable.jsx
+++ b/src/components/time-entry/TimeEntryTable.jsx
@@ -6,6 +6,7 @@ import { ChevronLeft, ChevronRight } from "lucide-react";
 import { format, startOfMonth, endOfMonth, eachDayOfInterval, isToday, parseISO } from "date-fns";
 import { he } from "date-fns/locale";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import TimeEntryForm from './TimeEntryForm'; // Assuming it's in the same folder
 
 export default function TimeEntryTable({ employees, workSessions, services, getRateForDate, onTableSubmit }) {
@@ -260,23 +261,46 @@ export default function TimeEntryTable({ employees, workSessions, services, getR
             </DialogDescription>
             </DialogHeader>
             {editingCell && (
-            <TimeEntryForm
-                employee={editingCell.employee}
-                services={services}
-                initialRows={editingCell.existingSessions}
-                selectedDate={editingCell.day}
-                getRateForDate={getRateForDate}
-                
-                onSubmit={(updatedRows) => {
-                    onTableSubmit({
-                    employee: editingCell.employee,
-                    day: editingCell.day,
-                    updatedRows,
-                    existingSessions: editingCell.existingSessions,
-                    });
-                    setEditingCell(null);
-                }}
-            />
+              <Tabs defaultValue={editingCell.existingSessions.length ? 'edit' : 'add'}>
+                <TabsList className="grid w-full grid-cols-2 mb-4">
+                  <TabsTrigger value="add">הוספת רישום חדש</TabsTrigger>
+                  <TabsTrigger value="edit" disabled={!editingCell.existingSessions.length}>עריכת רישומים קיימים</TabsTrigger>
+                </TabsList>
+                <TabsContent value="add">
+                  <TimeEntryForm
+                    employee={editingCell.employee}
+                    services={services}
+                    selectedDate={editingCell.day}
+                    getRateForDate={getRateForDate}
+                    onSubmit={(updatedRows) => {
+                      onTableSubmit({
+                        employee: editingCell.employee,
+                        day: editingCell.day,
+                        updatedRows,
+                      });
+                      setEditingCell(null);
+                    }}
+                  />
+                </TabsContent>
+                <TabsContent value="edit">
+                  <TimeEntryForm
+                    employee={editingCell.employee}
+                    services={services}
+                    initialRows={editingCell.existingSessions}
+                    selectedDate={editingCell.day}
+                    getRateForDate={getRateForDate}
+                    allowAddRow={false}
+                    onSubmit={(updatedRows) => {
+                      onTableSubmit({
+                        employee: editingCell.employee,
+                        day: editingCell.day,
+                        updatedRows,
+                      });
+                      setEditingCell(null);
+                    }}
+                  />
+                </TabsContent>
+              </Tabs>
             )}
         </DialogContent>
         </Dialog>


### PR DESCRIPTION
## Summary
- insert new table-view work sessions without ids so the database generates them
- split table dialog into tabs for adding new sessions versus editing existing ones
- document that only existing WorkSessions should include ids

## Testing
- `npx eslint src/Pages/TimeEntry.jsx src/components/time-entry/TimeEntryForm.jsx src/components/time-entry/TimeEntryTable.jsx`
- `npm run build`
- No test script is configured

------
https://chatgpt.com/codex/tasks/task_e_68c2c65454f083309a1f9bff68d300a8