### PR TITLE
Add orgId route binding to org-keys function

### DIFF
--- a/api/org-keys/function.json
+++ b/api/org-keys/function.json
@@ -4,6 +4,7 @@
       "authLevel": "anonymous",
       "type": "httpTrigger",
       "direction": "in",
+      "name": "req",
       "methods": [ "get" ],
       "route": "org/{orgId}/keys"
     },

--- a/api/org-keys/index.js
+++ b/api/org-keys/index.js
@@ -29,7 +29,7 @@ async function parseJsonResponse(response) {
 
 export default async function (context, req) {
   const env = readEnv(context);
-  const orgId = context?.bindingData?.orgId;
+  const orgId = context.bindingData?.orgId;
 
   if (!orgId) {
     context.log?.warn?.('org-keys missing orgId');


### PR DESCRIPTION
## Summary
- ensure the org-keys HTTP trigger exposes an orgId parameter in its route binding
- read the orgId value from Azure Functions binding data before calling Supabase

## Testing
- npx eslint api/org-keys/index.js
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d00848703c8330a702fb719c6b5752