### PR TITLE
refactor: support dev supabase credentials

### DIFF
--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -1,10 +1,44 @@
 import { activateConfig, loadRuntimeConfig } from './runtime/config.js';
 import { renderConfigError } from './runtime/ConfigErrorScreen.jsx';
 
+async function resolveBootstrapConfig() {
+  const mode = import.meta?.env?.MODE;
+
+  if (mode === 'development') {
+    console.log('[Bootstrap] Running in DEVELOPMENT mode. Using local .env variables.');
+    const supabaseUrl = import.meta?.env?.VITE_APP_SUPABASE_URL;
+    const supabaseAnonKey = import.meta?.env?.VITE_APP_SUPABASE_ANON_KEY;
+
+    if (!supabaseUrl || !supabaseAnonKey) {
+      throw new Error(
+        'Missing VITE_APP_SUPABASE_URL or VITE_APP_SUPABASE_ANON_KEY in .env.local file for development.',
+      );
+    }
+
+    return {
+      config: {
+        supabaseUrl,
+        supabaseAnonKey,
+        source: 'env',
+        orgId: null,
+      },
+      activated: false,
+    };
+  }
+
+  console.log('[Bootstrap] Running in PRODUCTION mode. Fetching config from API.');
+  const config = await loadRuntimeConfig();
+  return { config, activated: true };
+}
+
 async function bootstrap() {
   try {
-    const config = await loadRuntimeConfig();
-    await activateConfig(config, { source: config?.source || 'api', orgId: config?.orgId ?? null });
+    const { config, activated } = await resolveBootstrapConfig();
+
+    if (!activated) {
+      await activateConfig(config, { source: config?.source || 'env', orgId: config?.orgId ?? null });
+    }
+
     const { renderApp } = await import('./main.jsx');
     renderApp(config);
   } catch (error) {


### PR DESCRIPTION
## Summary
- introduce a bootstrap config resolver that reads Supabase credentials from Vite env vars during local development
- keep production fetching from `/api/config` while avoiding duplicate runtime activation when config already loaded

## Testing
- npm run build
- npx eslint . *(fails: existing repo lint errors outside the change)*
- npx eslint src/bootstrap.js

------
https://chatgpt.com/codex/tasks/task_e_68d3cc04df0c83308dcbd5a68fda7c6e