### PR TITLE
Fix dev bootstrap to use env runtime config

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,11 @@
   </head>
   <body>
     <div id="root"></div>
+    <script type="module">
+      window.__APP_ENV__ = import.meta.env.MODE;
+      window.__APP_SUPABASE_URL__ = import.meta.env.VITE_APP_SUPABASE_URL;
+      window.__APP_SUPABASE_ANON_KEY__ = import.meta.env.VITE_APP_SUPABASE_ANON_KEY;
+    </script>
     <script src="/runtime-config.js"></script>
     <script type="module" src="/src/bootstrap.js"></script>
   </body>

--- a/public/runtime-config.js
+++ b/public/runtime-config.js
@@ -37,6 +37,27 @@
     }
   }
 
+  const envMode = globalScope.__APP_ENV__;
+
+  if (envMode === 'development') {
+    const devConfig = normalizeConfig(
+      {
+        supabaseUrl: globalScope.__APP_SUPABASE_URL__,
+        supabaseAnonKey: globalScope.__APP_SUPABASE_ANON_KEY__,
+        orgId: null,
+        source: 'env',
+      },
+      'env',
+    );
+
+    if (!devConfig) {
+      console.warn('[runtime-config] missing development Supabase credentials.');
+    }
+
+    assignRuntimeConfig(devConfig);
+    return;
+  }
+
   if (globalScope.__RUNTIME_CONFIG__ && typeof globalScope.__RUNTIME_CONFIG__ === 'object') {
     const normalizedExisting = normalizeConfig(globalScope.__RUNTIME_CONFIG__, 'inline');
     assignRuntimeConfig(normalizedExisting);


### PR DESCRIPTION
## Summary
- expose the Vite environment values on window before loading the runtime-config preload script
- short-circuit runtime-config.js in development so it uses the injected Supabase credentials instead of hitting /api/config

## Testing
- npm run build
- npx eslint . (aborted after an extended runtime; reran targeted lint below)
- npx eslint public/runtime-config.js

------
https://chatgpt.com/codex/tasks/task_e_68d3d2f773d883309d404d6394dc8d60