### PR TITLE
Fix runtime config preload timing in development

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,19 @@
   </head>
   <body>
     <div id="root"></div>
+    <script type="module">
+      const {
+        MODE,
+        VITE_APP_SUPABASE_URL,
+        VITE_APP_SUPABASE_ANON_KEY,
+      } = import.meta.env;
+
+      window.__APP_ENV__ = MODE;
+      window.__APP_SUPABASE_URL__ = VITE_APP_SUPABASE_URL;
+      window.__APP_SUPABASE_ANON_KEY__ = VITE_APP_SUPABASE_ANON_KEY;
+
+      window.dispatchEvent(new CustomEvent('app:env-ready'));
+    </script>
     <script src="/runtime-config.js"></script>
     <script type="module" src="/src/bootstrap.js"></script>
   </body>

--- a/public/runtime-config.js
+++ b/public/runtime-config.js
@@ -1,4 +1,4 @@
-(function preloadRuntimeConfig() {
+(function setupRuntimeConfigPreload() {
   const globalScope = typeof window !== 'undefined' ? window : undefined;
   if (!globalScope) {
     return;
@@ -37,42 +37,88 @@
     }
   }
 
-  if (globalScope.__RUNTIME_CONFIG__ && typeof globalScope.__RUNTIME_CONFIG__ === 'object') {
-    const normalizedExisting = normalizeConfig(globalScope.__RUNTIME_CONFIG__, 'inline');
-    assignRuntimeConfig(normalizedExisting);
+  function initializeRuntimeConfig() {
+    if (initializeRuntimeConfig.__didRun) {
+      return;
+    }
+    initializeRuntimeConfig.__didRun = true;
+
+    const envMode = globalScope.__APP_ENV__;
+
+    if (envMode === 'development') {
+      const devConfig = normalizeConfig(
+        {
+          supabaseUrl: globalScope.__APP_SUPABASE_URL__,
+          supabaseAnonKey: globalScope.__APP_SUPABASE_ANON_KEY__,
+          orgId: null,
+          source: 'env',
+        },
+        'env',
+      );
+
+      if (!devConfig) {
+        console.warn('[runtime-config] missing development Supabase credentials.');
+      }
+
+      assignRuntimeConfig(devConfig);
+      return;
+    }
+
+    if (globalScope.__RUNTIME_CONFIG__ && typeof globalScope.__RUNTIME_CONFIG__ === 'object') {
+      const normalizedExisting = normalizeConfig(globalScope.__RUNTIME_CONFIG__, 'inline');
+      assignRuntimeConfig(normalizedExisting);
+      return;
+    }
+
+    let normalized = null;
+
+    try {
+      const inlineNode = document.querySelector('script[type="application/json"][data-runtime-config]');
+      if (inlineNode?.textContent) {
+        const inlinePayload = JSON.parse(inlineNode.textContent);
+        normalized = normalizeConfig(inlinePayload, 'inline');
+      }
+    } catch (error) {
+      console.warn('[runtime-config] failed to parse inline config', error);
+    }
+
+    if (!normalized) {
+      try {
+        const request = new XMLHttpRequest();
+        request.open('GET', '/api/config', false);
+        request.setRequestHeader('Accept', 'application/json');
+        request.send(null);
+
+        if (request.status >= 200 && request.status < 300) {
+          const responseText = request.responseText || '';
+          if (responseText.trim()) {
+            const payload = JSON.parse(responseText);
+            normalized = normalizeConfig(payload, 'preload');
+          }
+        }
+      } catch (error) {
+        console.warn('[runtime-config] failed to preload configuration', error);
+      }
+    }
+
+    assignRuntimeConfig(normalized);
+  }
+
+  if (typeof globalScope.__APP_ENV__ !== 'undefined') {
+    initializeRuntimeConfig();
     return;
   }
 
-  let normalized = null;
-
-  try {
-    const inlineNode = document.querySelector('script[type="application/json"][data-runtime-config]');
-    if (inlineNode?.textContent) {
-      const inlinePayload = JSON.parse(inlineNode.textContent);
-      normalized = normalizeConfig(inlinePayload, 'inline');
-    }
-  } catch (error) {
-    console.warn('[runtime-config] failed to parse inline config', error);
+  function handleEnvReady() {
+    globalScope.removeEventListener('app:env-ready', handleEnvReady);
+    initializeRuntimeConfig();
   }
 
-  if (!normalized) {
-    try {
-      const request = new XMLHttpRequest();
-      request.open('GET', '/api/config', false);
-      request.setRequestHeader('Accept', 'application/json');
-      request.send(null);
-
-      if (request.status >= 200 && request.status < 300) {
-        const responseText = request.responseText || '';
-        if (responseText.trim()) {
-          const payload = JSON.parse(responseText);
-          normalized = normalizeConfig(payload, 'preload');
-        }
-      }
-    } catch (error) {
-      console.warn('[runtime-config] failed to preload configuration', error);
-    }
+  if (typeof globalScope.addEventListener !== 'function') {
+    initializeRuntimeConfig();
+    return;
   }
 
-  assignRuntimeConfig(normalized);
+  globalScope.addEventListener('app:env-ready', handleEnvReady);
+  globalScope.addEventListener('DOMContentLoaded', initializeRuntimeConfig, { once: true });
 })();


### PR DESCRIPTION
## Summary
- dispatch a readiness event after exposing the Vite env values on window before the runtime-config preload runs
- defer runtime-config initialization until the env preload has populated globals, preserving the production fetch logic as a fallback

## Testing
- npm run build
- npx eslint . *(fails with pre-existing violations in unrelated files)*
- npx eslint public/runtime-config.js

------
https://chatgpt.com/codex/tasks/task_e_68d3d2f773d883309d404d6394dc8d60