### PR TITLE
Fix runtime config preload order for dev mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,36 @@
   </head>
   <body>
     <div id="root"></div>
+    <script type="module">
+      const globalScope = typeof window !== 'undefined' ? window : undefined;
+
+      if (globalScope) {
+        const {
+          MODE,
+          DEV,
+          PROD,
+          VITE_APP_SUPABASE_URL,
+          VITE_APP_SUPABASE_ANON_KEY,
+        } = import.meta.env || {};
+
+        const envMode =
+          typeof MODE === 'string' && MODE
+            ? MODE
+            : DEV
+              ? 'development'
+              : PROD
+                ? 'production'
+                : undefined;
+
+        globalScope.__APP_ENV__ = envMode;
+        globalScope.__APP_SUPABASE_URL__ = VITE_APP_SUPABASE_URL;
+        globalScope.__APP_SUPABASE_ANON_KEY__ = VITE_APP_SUPABASE_ANON_KEY;
+
+        if (typeof globalScope.dispatchEvent === 'function') {
+          globalScope.dispatchEvent(new CustomEvent('app:env-ready'));
+        }
+      }
+    </script>
     <script src="/runtime-config.js"></script>
     <script type="module" src="/src/bootstrap.js"></script>
   </body>

--- a/public/runtime-config.js
+++ b/public/runtime-config.js
@@ -1,4 +1,4 @@
-(function preloadRuntimeConfig() {
+(function setupRuntimeConfigPreload() {
   const globalScope = typeof window !== 'undefined' ? window : undefined;
   if (!globalScope) {
     return;
@@ -37,42 +37,97 @@
     }
   }
 
-  if (globalScope.__RUNTIME_CONFIG__ && typeof globalScope.__RUNTIME_CONFIG__ === 'object') {
-    const normalizedExisting = normalizeConfig(globalScope.__RUNTIME_CONFIG__, 'inline');
-    assignRuntimeConfig(normalizedExisting);
+  function buildDevRuntimeConfig() {
+    return normalizeConfig(
+      {
+        supabaseUrl: globalScope.__APP_SUPABASE_URL__,
+        supabaseAnonKey: globalScope.__APP_SUPABASE_ANON_KEY__,
+        orgId: null,
+        source: 'env',
+      },
+      'env',
+    );
+  }
+
+  function initializeRuntimeConfig() {
+    if (initializeRuntimeConfig.__didRun) {
+      return;
+    }
+
+    const envMode = globalScope.__APP_ENV__;
+
+    if (typeof envMode === 'undefined') {
+      return;
+    }
+
+    initializeRuntimeConfig.__didRun = true;
+
+    if (envMode === 'development') {
+      const devConfig = buildDevRuntimeConfig();
+
+      if (!devConfig) {
+        console.warn('[runtime-config] missing development Supabase credentials.');
+      }
+
+      assignRuntimeConfig(devConfig);
+      return;
+    }
+
+    if (globalScope.__RUNTIME_CONFIG__ && typeof globalScope.__RUNTIME_CONFIG__ === 'object') {
+      const normalizedExisting = normalizeConfig(globalScope.__RUNTIME_CONFIG__, 'inline');
+      assignRuntimeConfig(normalizedExisting);
+      return;
+    }
+
+    let normalized = null;
+
+    try {
+      const inlineNode = document.querySelector('script[type="application/json"][data-runtime-config]');
+      if (inlineNode?.textContent) {
+        const inlinePayload = JSON.parse(inlineNode.textContent);
+        normalized = normalizeConfig(inlinePayload, 'inline');
+      }
+    } catch (error) {
+      console.warn('[runtime-config] failed to parse inline config', error);
+    }
+
+    if (!normalized) {
+      try {
+        const request = new XMLHttpRequest();
+        request.open('GET', '/api/config', false);
+        request.setRequestHeader('Accept', 'application/json');
+        request.send(null);
+
+        if (request.status >= 200 && request.status < 300) {
+          const responseText = request.responseText || '';
+          if (responseText.trim()) {
+            const payload = JSON.parse(responseText);
+            normalized = normalizeConfig(payload, 'preload');
+          }
+        }
+      } catch (error) {
+        console.warn('[runtime-config] failed to preload configuration', error);
+      }
+    }
+
+    assignRuntimeConfig(normalized);
+  }
+
+  function handleEnvReady() {
+    globalScope.removeEventListener('app:env-ready', handleEnvReady);
+    initializeRuntimeConfig();
+  }
+
+  if (typeof globalScope.__APP_ENV__ !== 'undefined') {
+    initializeRuntimeConfig();
     return;
   }
 
-  let normalized = null;
-
-  try {
-    const inlineNode = document.querySelector('script[type="application/json"][data-runtime-config]');
-    if (inlineNode?.textContent) {
-      const inlinePayload = JSON.parse(inlineNode.textContent);
-      normalized = normalizeConfig(inlinePayload, 'inline');
-    }
-  } catch (error) {
-    console.warn('[runtime-config] failed to parse inline config', error);
+  if (typeof globalScope.addEventListener !== 'function') {
+    initializeRuntimeConfig();
+    return;
   }
 
-  if (!normalized) {
-    try {
-      const request = new XMLHttpRequest();
-      request.open('GET', '/api/config', false);
-      request.setRequestHeader('Accept', 'application/json');
-      request.send(null);
-
-      if (request.status >= 200 && request.status < 300) {
-        const responseText = request.responseText || '';
-        if (responseText.trim()) {
-          const payload = JSON.parse(responseText);
-          normalized = normalizeConfig(payload, 'preload');
-        }
-      }
-    } catch (error) {
-      console.warn('[runtime-config] failed to preload configuration', error);
-    }
-  }
-
-  assignRuntimeConfig(normalized);
+  globalScope.addEventListener('app:env-ready', handleEnvReady);
+  globalScope.addEventListener('DOMContentLoaded', initializeRuntimeConfig, { once: true });
 })();


### PR DESCRIPTION
## Summary
- inline the Vite env exposure in `index.html` so window globals are ready before the legacy preload runs
- update `public/runtime-config.js` to wait for the env flag before running and to short-circuit cleanly in development
- drop the unused `src/env-preload.js` helper now that the bootstrap runs directly from HTML

## Testing
- npm run build
- npx eslint . *(fails with existing violations in components/ui/*, src/lib/layoutSwap.js, tailwind.config.js, tmp_TimeEntryTable.jsx, and vite.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68d3d2f773d883309d404d6394dc8d60