### PR TITLE
Switch employee bundle fetch to sequential diagnostics

### DIFF
--- a/api/employees/index.js
+++ b/api/employees/index.js
@@ -228,35 +228,51 @@ async function ensureMembership(supabase, orgId, userId) {
 }
 
 async function fetchEmployeesBundle(tenantClient) {
-  const [employeesResult, ratesResult, servicesResult, leaveBalancesResult, settingsResult] = await Promise.all([
-    tenantClient.from('Employees').select('*').order('name'),
-    tenantClient.from('RateHistory').select('*'),
-    tenantClient.from('Services').select('*'),
-    tenantClient.from('LeaveBalances').select('*'),
-    tenantClient
-      .from('Settings')
-      .select('key, settings_value')
-      .in('key', ['leave_policy', 'leave_pay_policy']),
-  ]);
+  console.log('[DIAGNOSTIC TEST RUNNING]');
 
-  const errors = [
-    employeesResult.error,
-    ratesResult.error,
-    servicesResult.error,
-    leaveBalancesResult.error,
-    settingsResult.error,
-  ].filter(Boolean);
-
-  if (errors.length) {
-    const [firstError] = errors;
-    return { error: firstError || new Error('unknown_error') };
+  // Test 1: Employees
+  const employeesResult = await tenantClient.from('Employees').select('*').order('name');
+  if (employeesResult.error) {
+    console.error('DIAGNOSTIC FAILED ON: Employees', employeesResult.error);
+    return { error: new Error('Failed on Employees table') };
   }
+  console.log('DIAGNOSTIC PASSED: Employees');
 
+  // Test 2: RateHistory
+  const ratesResult = await tenantClient.from('RateHistory').select('*');
+  if (ratesResult.error) {
+    console.error('DIAGNOSTIC FAILED ON: RateHistory', ratesResult.error);
+    return { error: new Error('Failed on RateHistory table') };
+  }
+  console.log('DIAGNOSTIC PASSED: RateHistory');
+
+  // Test 3: Services
+  const servicesResult = await tenantClient.from('Services').select('*');
+  if (servicesResult.error) {
+    console.error('DIAGNOSTIC FAILED ON: Services', servicesResult.error);
+    return { error: new Error('Failed on Services table') };
+  }
+  console.log('DIAGNOSTIC PASSED: Services');
+
+  // Test 4: LeaveBalances
+  const leaveBalancesResult = await tenantClient.from('LeaveBalances').select('*');
+  if (leaveBalancesResult.error) {
+    console.error('DIAGNOSTIC FAILED ON: LeaveBalances', leaveBalancesResult.error);
+    return { error: new Error('Failed on LeaveBalances table') };
+  }
+  console.log('DIAGNOSTIC PASSED: LeaveBalances');
+
+  // Test 5: Settings
+  const settingsResult = await tenantClient.from('Settings').select('key, settings_value').in('key', ['leave_policy', 'leave_pay_policy']);
+  if (settingsResult.error) {
+    console.error('DIAGNOSTIC FAILED ON: Settings', settingsResult.error);
+    return { error: new Error('Failed on Settings table') };
+  }
+  console.log('DIAGNOSTIC PASSED: Settings');
+
+  // If all tests passed, return data
   const settingsMap = new Map();
   for (const entry of settingsResult.data || []) {
-    if (!entry || typeof entry.key !== 'string') {
-      continue;
-    }
     settingsMap.set(entry.key, entry.settings_value ?? null);
   }
 

--- a/src/components/settings/SetupAssistant.jsx
+++ b/src/components/settings/SetupAssistant.jsx
@@ -60,6 +60,7 @@ const TABLE_LABELS = {
   Services: 'שירותים והצעות',
   Settings: 'הגדרות ארגון',
   app_user_role_grants: 'הרשאות תפקיד app_user',
+  services_default_rate_seed: 'תעריף כללי (שורת שירות ברירת מחדל)',
 };
 
 

--- a/src/components/settings/SetupAssistant.jsx
+++ b/src/components/settings/SetupAssistant.jsx
@@ -59,6 +59,7 @@ const TABLE_LABELS = {
   RateHistory: 'היסטוריית תעריפים',
   Services: 'שירותים והצעות',
   Settings: 'הגדרות ארגון',
+  rate_history_unique_constraint: 'מפתח ייחודי להיסטוריית תעריפים (עובד/שירות/תאריך)',
   app_user_role_grants: 'הרשאות תפקיד app_user',
   services_default_rate_seed: 'תעריף כללי (שורת שירות ברירת מחדל)',
 };

--- a/src/components/settings/SetupAssistant.jsx
+++ b/src/components/settings/SetupAssistant.jsx
@@ -59,6 +59,7 @@ const TABLE_LABELS = {
   RateHistory: 'היסטוריית תעריפים',
   Services: 'שירותים והצעות',
   Settings: 'הגדרות ארגון',
+  app_user_role_grants: 'הרשאות תפקיד app_user',
 };
 
 

--- a/src/lib/setup-sql.js
+++ b/src/lib/setup-sql.js
@@ -36,7 +36,10 @@ create table if not exists public."Services" (
   constraint "Services_pkey" primary key ("id")
 );
 
-INSERT INTO "public"."Services" ("id", "name", "duration_minutes", "payment_model", "color", "metadata") VALUES ('00000000-0000-0000-0000-000000000000', 'תעריף כללי *לא למחוק או לשנות*', null, 'fixed_rate', '#84CC16', null);
+-- Ensure the generic, non-deletable service for general rates exists.
+INSERT INTO "public"."Services" ("id", "name", "duration_minutes", "payment_model", "color", "metadata")
+VALUES ('00000000-0000-0000-0000-000000000000', 'תעריף כללי *לא למחוק או לשנות*', null, 'fixed_rate', '#84CC16', null)
+ON CONFLICT (id) DO NOTHING;
 
 create table if not exists public."RateHistory" (
   "id" uuid not null default gen_random_uuid(),
@@ -51,6 +54,7 @@ create table if not exists public."RateHistory" (
   constraint "RateHistory_service_id_fkey" foreign key ("service_id") references public."Services"("id")
 );
 
+-- Add a unique constraint to support upsert operations on rate history.
 ALTER TABLE public."RateHistory"
 ADD CONSTRAINT "RateHistory_employee_service_effective_date_key"
 UNIQUE (employee_id, service_id, effective_date);
@@ -541,6 +545,7 @@ GRANT ALL ON ALL TABLES IN SCHEMA public TO app_user;
 ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO app_user;
 GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO app_user;
 ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE, SELECT ON SEQUENCES TO app_user;
+-- Allow the anonymous and postgres roles to impersonate the app_user role.
 GRANT app_user TO postgres, anon;
 
 -- שלב 4: יצירת מפתח גישה ייעודי (JWT) עבור התפקיד החדש


### PR DESCRIPTION
## Summary
- replace the employee bundle query helper with a sequential diagnostic implementation
- log progress and return early when any individual query fails to identify the problematic table

## Testing
- npx eslint api/employees/index.js
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d452f0bb1483309dab21e38cd80e65