### PR TITLE
Add employment scope support to employee backend

### DIFF
--- a/api/employees/index.js
+++ b/api/employees/index.js
@@ -292,6 +292,15 @@ function normalizeEmployeePayload(raw) {
   }
 
   const payload = { ...raw };
+  if (Object.prototype.hasOwnProperty.call(payload, 'employment_scope')) {
+    const value = payload.employment_scope;
+    if (typeof value === 'string') {
+      const trimmed = value.trim();
+      payload.employment_scope = trimmed ? trimmed : null;
+    } else {
+      payload.employment_scope = null;
+    }
+  }
   if (payload.annual_leave_days !== undefined && payload.annual_leave_days !== null) {
     const parsed = Number(payload.annual_leave_days);
     payload.annual_leave_days = Number.isNaN(parsed) ? 0 : parsed;

--- a/src/lib/setup-sql.js
+++ b/src/lib/setup-sql.js
@@ -26,6 +26,9 @@ create table if not exists public."Employees" (
   constraint "Employees_pkey" primary key ("id")
 );
 
+ALTER TABLE "public"."Employees"
+ADD COLUMN IF NOT EXISTS "employment_scope" TEXT;
+
 create table if not exists public."Services" (
   "id" uuid not null default gen_random_uuid(),
   "name" text not null,


### PR DESCRIPTION
## Summary
- add an idempotent ALTER TABLE statement to provision the employment_scope column for Employees
- normalize the employees API payload to trim and persist the employment_scope value when provided

## Testing
- npm run check:schema *(fails: Missing Supabase credentials. Set APP_SUPABASE_URL and APP_SUPABASE_SERVICE_ROLE (or anon key) to run the schema check.)*
- npm run build
- npx eslint api/employees/index.js src/lib/setup-sql.js

------
https://chatgpt.com/codex/tasks/task_e_68e42920bed48330a35224e62131a626